### PR TITLE
Add blog post template.

### DIFF
--- a/data/blog-posts/013.md
+++ b/data/blog-posts/013.md
@@ -1,0 +1,90 @@
+---
+number: "001"
+title: "Welcome to the Gimbalabs Blog"
+subtitle: "Looking back at 2023"
+author: "James Dunseith"
+date: "2024-01-02"
+version: 1
+videoId: ""
+videoTitle: ""
+path: "/blog/001"
+videos:
+  [
+  ]
+fullWidthImageAndText:
+  {
+    src: "/csks/002cover.png",
+    title: "Blog Post #1",
+    subtitle: "First post",
+    orientation: "right",
+  }
+objectives:
+  {
+    title: "Learning Targets",
+    list:
+      [
+        "I take a problem-sensing approach to talking about Cardano with my friends and family.",
+      ],
+  }
+recirc:
+  { image: "/csks/002cover.png", color: "bg-blue-600", list: ["csk001", "csk003", "csk004"] }
+---
+
+Happy New Year, and welcome to the brand-new Gimbalabs blog!
+
+Gimbalabs was founded in late-2020 by three people who met during Funds 1 and 2 of Cardano’s Project Catalyst. Since then, we’ve tried some things, we've failed often, and we've remained steadily committed to making space for people to come together and make sense of new ideas.
+
+One of the nice things about starting this blog is that over the next few months, we can share more about the history of Gimbalabs. In this post, I won’t try to cover all of that. A core value of Gimbalabs is *getting started*, in whatever way possible, and making space for next steps to happen. So today, we're launching this blog.
+
+Let's start here: my name is James. I’m one of the three co-founders of Gimbalabs, along with Juliane Montag and Roberto C. Morano. In the last three years, I have met some of the most creative, thoughtful and talented people I could ever hope to meet. I've also witnessed the challenges that come with building new ways of working together in a nascent "decentralized" ecosystem.
+
+In 2024, my goal is to find out whether Gimbalabs needs to exist. If it does, we'll know because a group of contributors will be sharing in the sustained & sustainable development of Gimbalabs. Right now, I like our chances of finding out that Gimbalabs is a thriving and supportive community organization, that helps people to build things that really matter. Let's see what happens!
+
+In this post, I’ll take a quick look back at 2023. In the next post, I’ll take a quick look ahead at 2024. Then, on Wednesday, 2024-01-10 at 1430 UTC we will convene the first [Gimbalabs PBL Governance Session](https://plutuspbl.io/governance).
+
+## Gimbalabs in 2023
+
+In 2023, Gimbalabs was a loose space for people to get together, learn and build. We focused on continuing to run [Gimbalabs Playground](/playground), we supported some partner projects that we’re really excited about (more on those soon), and we created the [Plutus Project-Based Learning (PPBL) 2023](https://plutuspbl.io/) course.
+
+### Gimbalabs Playground in 2023
+
+Gimbalabs Playground meets on Tuesdays from 1800 to 1930 UTC. You can [learn more about it here](/playground). Playground is an open space where anyone is welcome to share an idea, a project they're working on, or a big question they have. It's a space that bridges the divide between "technical" and "non-technical" folks, and where all us can make sense of the implications of new technology.
+
+In 2023, we saw presentations from dozens of community members about a wide variety of topics. Most Playground sessions were live-streamed and [archived on the Gimbalabs YouTube channel](https://www.youtube.com/@gimbalabs/streams).
+
+Gimbalabs Playground will continue to meet weekly through May, 2024, starting again on [Tuesday 2024-01-09](/calendar). The best way to learn about it [is to stop by](https://us06web.zoom.us/meeting/register/tZYoduuqpjsqGtdzMHXoRVVnJqcQGOtpQRQv#/registration).
+
+### Plutus Project-Based Learning (PPBL) in 2023
+
+In the last year, our main focus has been on building the Plutus Project-Based Learning course. We called it “PPBL 2023”, and the archived course can be viewed at [plutuspbl.io](https://plutuspbl.io/)
+
+The goal of PPBL 2023 is to support people to learn enough about Cardano development to become contributors to real projects. In the last two years, the course has [helped onboard over 200 developers](https://plutuspbl.io/contributors) to the Cardano ecosystem.
+
+PPBL 2023 was the fourth iteration of Plutus PBL. By delivering it, our team accomplished several objectives:
+- Creating a set of lessons that invite students to learn about Cardano by completing a series of projects.
+- Prototyping a learning and contribution management platform, called "Andamio".
+- Forming a community that meets for Live Coding sessions twice each week.
+
+In 2024, we will continue this work by:
+- Updating the lesson content from PPBL 2023 to release PPBL 2024. All of the lessons and code examples can now be revised and used in the upcoming course.
+- Using the Andamio Platform to deliver PPBL 2024.
+- Moving from "Live Coding" to [Gimbalabs PBL Governance]() in January and February, 2024.
+
+If you participated in PPBL 2023 and have a [Contributor Token](https://plutuspbl.io/contributors), hold on to it! Your token is a prototype of a credential on Cardano's preproduction testnet (Preprod) and we're currently building a bridge to move those credentials and to Cardano Mainnet. I'm eager to share more in an upcoming post.
+
+
+### Launching Andamio
+
+[Andamio](https://www.andamio.io/) is currently in early-alpha release, and will continue to roll out in 2024. It is being built by a team of people who met participating in Project Catalyst and in prior iterations of Plutus PBL. We believe this process for forming teams and organizations can be replicated many times, and we've built that belief into Andamio.
+
+In the next blog post, I'll share more about what's next for Andamio, along with some intentions for Gimbalabs in 2024.
+
+Thanks for reading, and see you soon.
+
+---
+
+## Next Steps
+
+- Playground meets on Tuesdays at 1800 UTC. [Learn more and register here](/playground).
+- In January and February, [Gimbalabs PBL Governance Sessions](/governance) will take the place of Plutus PBL Live Coding. Governance sessions will meet on Wednesdays and Thursdays from 1430-1600 UTC, starting on Wednesday 2024-01-10.
+- In the next post, we'll take an introductory look at what's coming up for Gimbalabs in 2024.

--- a/data/blog-posts/013.md
+++ b/data/blog-posts/013.md
@@ -1,90 +1,39 @@
 ---
-number: "001"
-title: "Welcome to the Gimbalabs Blog"
-subtitle: "Looking back at 2023"
-author: "James Dunseith"
-date: "2024-01-02"
+number: "013"
+title: "Blog post Template"
+subtitle: "Copy and paste when creating new articles"
+author: "Aleksei Seregin"
+date: "2025-01-05"
 version: 1
 videoId: ""
 videoTitle: ""
-path: "/blog/001"
+path: "/blog/013"
 videos:
   [
   ]
 fullWidthImageAndText:
   {
     src: "/csks/002cover.png",
-    title: "Blog Post #1",
-    subtitle: "First post",
+    title: "Blog Post #13",
+    subtitle: "TODO:",
     orientation: "right",
   }
 objectives:
   {
-    title: "Learning Targets",
+    title: "TODO: read other articles to understand the purpose of this field",
     list:
       [
-        "I take a problem-sensing approach to talking about Cardano with my friends and family.",
+        "TODO: read other articles to understand the purpose of this field",
       ],
   }
 recirc:
   { image: "/csks/002cover.png", color: "bg-blue-600", list: ["csk001", "csk003", "csk004"] }
 ---
+Greetings!
 
-Happy New Year, and welcome to the brand-new Gimbalabs blog!
-
-Gimbalabs was founded in late-2020 by three people who met during Funds 1 and 2 of Cardano’s Project Catalyst. Since then, we’ve tried some things, we've failed often, and we've remained steadily committed to making space for people to come together and make sense of new ideas.
-
-One of the nice things about starting this blog is that over the next few months, we can share more about the history of Gimbalabs. In this post, I won’t try to cover all of that. A core value of Gimbalabs is *getting started*, in whatever way possible, and making space for next steps to happen. So today, we're launching this blog.
-
-Let's start here: my name is James. I’m one of the three co-founders of Gimbalabs, along with Juliane Montag and Roberto C. Morano. In the last three years, I have met some of the most creative, thoughtful and talented people I could ever hope to meet. I've also witnessed the challenges that come with building new ways of working together in a nascent "decentralized" ecosystem.
-
-In 2024, my goal is to find out whether Gimbalabs needs to exist. If it does, we'll know because a group of contributors will be sharing in the sustained & sustainable development of Gimbalabs. Right now, I like our chances of finding out that Gimbalabs is a thriving and supportive community organization, that helps people to build things that really matter. Let's see what happens!
-
-In this post, I’ll take a quick look back at 2023. In the next post, I’ll take a quick look ahead at 2024. Then, on Wednesday, 2024-01-10 at 1430 UTC we will convene the first [Gimbalabs PBL Governance Session](https://plutuspbl.io/governance).
-
-## Gimbalabs in 2023
-
-In 2023, Gimbalabs was a loose space for people to get together, learn and build. We focused on continuing to run [Gimbalabs Playground](/playground), we supported some partner projects that we’re really excited about (more on those soon), and we created the [Plutus Project-Based Learning (PPBL) 2023](https://plutuspbl.io/) course.
-
-### Gimbalabs Playground in 2023
-
-Gimbalabs Playground meets on Tuesdays from 1800 to 1930 UTC. You can [learn more about it here](/playground). Playground is an open space where anyone is welcome to share an idea, a project they're working on, or a big question they have. It's a space that bridges the divide between "technical" and "non-technical" folks, and where all us can make sense of the implications of new technology.
-
-In 2023, we saw presentations from dozens of community members about a wide variety of topics. Most Playground sessions were live-streamed and [archived on the Gimbalabs YouTube channel](https://www.youtube.com/@gimbalabs/streams).
-
-Gimbalabs Playground will continue to meet weekly through May, 2024, starting again on [Tuesday 2024-01-09](/calendar). The best way to learn about it [is to stop by](https://us06web.zoom.us/meeting/register/tZYoduuqpjsqGtdzMHXoRVVnJqcQGOtpQRQv#/registration).
-
-### Plutus Project-Based Learning (PPBL) in 2023
-
-In the last year, our main focus has been on building the Plutus Project-Based Learning course. We called it “PPBL 2023”, and the archived course can be viewed at [plutuspbl.io](https://plutuspbl.io/)
-
-The goal of PPBL 2023 is to support people to learn enough about Cardano development to become contributors to real projects. In the last two years, the course has [helped onboard over 200 developers](https://plutuspbl.io/contributors) to the Cardano ecosystem.
-
-PPBL 2023 was the fourth iteration of Plutus PBL. By delivering it, our team accomplished several objectives:
-- Creating a set of lessons that invite students to learn about Cardano by completing a series of projects.
-- Prototyping a learning and contribution management platform, called "Andamio".
-- Forming a community that meets for Live Coding sessions twice each week.
-
-In 2024, we will continue this work by:
-- Updating the lesson content from PPBL 2023 to release PPBL 2024. All of the lessons and code examples can now be revised and used in the upcoming course.
-- Using the Andamio Platform to deliver PPBL 2024.
-- Moving from "Live Coding" to [Gimbalabs PBL Governance]() in January and February, 2024.
-
-If you participated in PPBL 2023 and have a [Contributor Token](https://plutuspbl.io/contributors), hold on to it! Your token is a prototype of a credential on Cardano's preproduction testnet (Preprod) and we're currently building a bridge to move those credentials and to Cardano Mainnet. I'm eager to share more in an upcoming post.
-
-
-### Launching Andamio
-
-[Andamio](https://www.andamio.io/) is currently in early-alpha release, and will continue to roll out in 2024. It is being built by a team of people who met participating in Project Catalyst and in prior iterations of Plutus PBL. We believe this process for forming teams and organizations can be replicated many times, and we've built that belief into Andamio.
-
-In the next blog post, I'll share more about what's next for Andamio, along with some intentions for Gimbalabs in 2024.
-
-Thanks for reading, and see you soon.
+!
 
 ---
 
 ## Next Steps
 
-- Playground meets on Tuesdays at 1800 UTC. [Learn more and register here](/playground).
-- In January and February, [Gimbalabs PBL Governance Sessions](/governance) will take the place of Plutus PBL Live Coding. Governance sessions will meet on Wednesdays and Thursdays from 1430-1600 UTC, starting on Wednesday 2024-01-10.
-- In the next post, we'll take an introductory look at what's coming up for Gimbalabs in 2024.


### PR DESCRIPTION
Adding a blog post template to a community website can make it better in several ways:

1. **Consistency**: A blog post template helps maintain a consistent look and feel across all blog posts, making it easier for readers to navigate and engage with the content.
2. **Efficiency**: A template saves time and effort for content creators, as they don't have to start from scratch each time they write a new blog post. They can simply fill in the template with their content.
3. **Organization**: A blog post template can include sections or fields that encourage content creators to include key information, such as a summary, keywords, or a call-to-action, making the content more organized and informative.
4. **Enhanced user experience**: A well-designed template can improve the reading experience for users, making it easier for them to scan and understand the content. This can lead to increased engagement, shares, and comments.
5. **Search Engine Optimization (SEO)**: A blog post template can include SEO-friendly elements, such as meta titles, descriptions, and headings, which can help improve the website's search engine rankings and visibility.
6. **Content strategy**: A template can help guide content creators in developing a consistent content strategy, including the types of content to create, the tone and style, and the key messaging.
7. **Scalability**: A blog post template makes it easier to scale the content creation process, as new authors or contributors can easily use the template to create new content.
8. **Brand consistency**: A template can help maintain the community website's brand identity, including the layout, colors, and typography, which can help build trust and recognition with the audience.
